### PR TITLE
added --legacy-peer-deps for launch project's default npm i command t…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 timeout=60000
+legacy-peer-deps=true


### PR DESCRIPTION
This ensures every time npm install runs — whether locally, on CI, or during deployment — it behaves like: npm install --legacy-peer-deps
